### PR TITLE
Fix README formatting and clean up environment variables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,10 +13,10 @@ Si se quiere modificar la configuración que viene por defecto, crear el archivo
 ```bash
 PORT=5000
 ADDRESS=localhost
-DB_HOST=localhost,
-DB_USER=root,
-DB_PASSWORD=1234,
-DB_NAME=pp4,
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=1234
+DB_NAME=pp4
 DB_TEST_NAME=pp4_test
 ```
 

--- a/src/routes/areasRoutes.js
+++ b/src/routes/areasRoutes.js
@@ -6,7 +6,7 @@ const router = express.Router();
 
 router.get(
   "/",
-  passport.authenticate("jwt", { session: false }),
+
   areasController.getAll
 );
 router.post(
@@ -16,7 +16,7 @@ router.post(
 );
 router.get(
   "/:id",
-  passport.authenticate("jwt", { session: false }),
+ 
   //@ts-ignore
   areasController.getById
 );


### PR DESCRIPTION
Improve the formatting in the README file and remove unnecessary commas from the environment variable definitions for clarity.