### PR TITLE
Refactor PedidoCandidatos to PedidoCandidato for consistency

### DIFF
--- a/src/services/pedidoCandidatosService.js
+++ b/src/services/pedidoCandidatosService.js
@@ -1,5 +1,5 @@
 import pool from "../config/db.js";
-import { PedidoCandidatosSchema } from "../types/schemas.js";
+import { PedidoCandidatoSchema } from "../types/schemas.js";
 
 /** @typedef {import("mysql2").QueryResult} QueryResult */
 /** @typedef {import("mysql2").FieldPacket} FieldPacket */
@@ -8,7 +8,7 @@ import { PedidoCandidatosSchema } from "../types/schemas.js";
 /** @typedef {import('../types').UpdateResult} UpdateResult */
 /** @typedef {import('../types').DeleteResult} DeleteResult */
 
-/** @typedef {import('../types').PedidoCandidatos} PedidoCandidatos */
+/** @typedef {import('../types').PedidoCandidato} PedidoCandidatos */
 
 /**
  * @returns {Promise<PedidoCandidatos[]>}
@@ -18,7 +18,7 @@ export async function getAllPedidoCandidatos() {
   const candidatos =
     Array.isArray(rows) &&
     rows.map((row) => {
-      const parsed = PedidoCandidatosSchema.safeParse(row);
+      const parsed = PedidoCandidatoSchema.safeParse(row);
       if (!parsed.success) {
         throw new Error("El resultado no es un PedidoCandidatos válido", {
           cause: parsed.error,
@@ -40,7 +40,7 @@ export async function getPedidoCandidatosById(id) {
   );
   const candidato = rows[0];
   if (!candidato) return null;
-  const parsed = PedidoCandidatosSchema.safeParse(candidato);
+  const parsed = PedidoCandidatoSchema.safeParse(candidato);
   if (!parsed.success) {
     throw new Error("El resultado no es un PedidoCandidatos válido", {
       cause: parsed.error,
@@ -61,7 +61,7 @@ export async function createPedidoCandidatos(pedidoCandidato) {
     [id, pedidoId, tecnicoId]
   );
 
-  const parsed = PedidoCandidatosSchema.safeParse({
+  const parsed = PedidoCandidatoSchema.safeParse({
     id: result.insertId,
     pedidoId,
     tecnicoId,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import { ClienteSchema, AreaSchema, UsuarioSchema, TecnicoSchema, PedidoSchema, PedidoCandidatosSchema, PedidoDisponibilidadSchema, PedidoEstadoEnum, PedidoDisponibilidadDiaEnum, TecnicoAreaSchema, UsuarioRolEnum, FacturaSchema, FacturaMetodoPagoEnum, UsuarioCompletoSchema, PedidoCompletoSchema } from './schemas';
+import { ClienteSchema, AreaSchema, UsuarioSchema, TecnicoSchema, PedidoSchema, PedidoCandidatoSchema, PedidoDisponibilidadSchema, PedidoEstadoEnum, PedidoDisponibilidadDiaEnum, TecnicoAreaSchema, UsuarioRolEnum, FacturaSchema, FacturaMetodoPagoEnum, UsuarioCompletoSchema, PedidoCompletoSchema, CandidatoVistaSchema } from './schemas';
 export type Cliente = z.infer<typeof ClienteSchema>;
 export type Area = z.infer<typeof AreaSchema>;
 export type Usuario = z.infer<typeof UsuarioSchema>;
 export type Tecnico = z.infer<typeof TecnicoSchema>;
 export type TecnicoArea = z.infer<typeof TecnicoAreaSchema>;
 export type Pedido = z.infer<typeof PedidoSchema>;
-export type PedidoCandidatos = z.infer<typeof PedidoCandidatosSchema>;
+export type PedidoCandidato = z.infer<typeof PedidoCandidatoSchema>;
 export type PedidoDisponibilidad = z.infer<typeof PedidoDisponibilidadSchema>;
 export type PedidoEstado = z.infer<typeof PedidoEstadoEnum>;
 export type PedidoDisponibilidadDia = z.infer<typeof PedidoDisponibilidadDiaEnum>;
@@ -15,7 +15,7 @@ export type Factura = z.infer<typeof FacturaSchema>;
 export type FacturaMetodoPago = z.infer<typeof FacturaMetodoPagoEnum>;
 export type UsuarioCompleto = z.infer<typeof UsuarioCompletoSchema>;
 export type PedidoCompleto = z.infer<typeof PedidoCompletoSchema>;
-
+export type CandidatoVista = z.infer<typeof CandidatoVistaSchema>;
 
 export type TecnicoConAreas = Tecnico & {
   areas: Area[] | null;

--- a/src/types/schemas.js
+++ b/src/types/schemas.js
@@ -94,7 +94,7 @@ export const PedidoDisponibilidadSchema = z.object({
 });
 
 // PedidoCandidatos
-export const PedidoCandidatosSchema = z.object({
+export const PedidoCandidatoSchema = z.object({
   id: z.number().nullable(),
   pedidoId: z.number().nullable(),
   tecnicoId: z.number().nullable(),
@@ -118,10 +118,21 @@ export const UsuarioCompletoSchema = UsuarioSchema.extend({
   tecnico: TecnicoSchema.optional().nullable(),
 });
 
+
+
+export const CandidatoVistaSchema = PedidoCandidatoSchema.extend({
+  nombre: z.string().nullable(),
+  apellido: z.string().nullable(),
+  telefono: z.string().nullable(),
+  caracteristicas: z.string().nullable(),
+  fechaRegistro: z.coerce.date().nullable(),
+  calificaciones: z.array(z.number().nullable()).optional().nullable(),
+});
+
 export const PedidoCompletoSchema = PedidoSchema.extend({
   cliente: ClienteSchema.optional().nullable(),
   tecnico: TecnicoSchema.optional().nullable(),
   area: AreaSchema.optional().nullable(),
   disponibilidad: z.array(PedidoDisponibilidadSchema).optional().nullable(),
-  candidatos: z.array(PedidoCandidatosSchema).optional().nullable(),
+  candidatos: z.array(CandidatoVistaSchema).optional().nullable(),
 });

--- a/test-api/pedido.http
+++ b/test-api/pedido.http
@@ -9,7 +9,7 @@ Authorization: Bearer {{token}}
 
 
 ### Obtener todos los pedidos
-GET /api/pedidos?clienteId=1 HTTP/1.1
+GET /api/pedidos?clienteId=57 HTTP/1.1
 Host: {{host}}
 Authorization: Bearer {{token}}
 


### PR DESCRIPTION
Rename and refactor the `PedidoCandidatos` schema and related functions to `PedidoCandidato` for improved clarity and consistency across the codebase. Update related schemas and queries accordingly.